### PR TITLE
chore: update base image to Ubuntu 25.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:25.04
 
 ADD --chmod=744 https://static.triply.cc/cli/triplydb-linux /bin/triplydb
 


### PR DESCRIPTION
Also updates TriplyDB CLI image, as it was updated since last build.